### PR TITLE
refactor: Update Terraform directory setup for parallelism

### DIFF
--- a/pkg/scenario/parallelism.go
+++ b/pkg/scenario/parallelism.go
@@ -2,12 +2,10 @@ package scenario
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/git"
-	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/Excoriate/tftest/pkg/tfdir"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 // SetupTerraformDirForParallelism sets up the Terraform directory for parallelism.
@@ -21,24 +19,10 @@ func SetupTerraformDirForParallelism(t *testing.T, tfDir string) (string, error)
 		return "", fmt.Errorf("tfDir is required")
 	}
 
-	// if the path is absolute we can just use it, otherwise we calculate the path relative to the git repo root
-	getRepoRoot := git.GetRepoRoot(t)
-	testDirRelPathFromGitRepo, err := resolveTfDir(tfDir, getRepoRoot)
+	testDirRelPathFromGitRepo, gitRepoRoot, err := tfdir.GetRelativePathFromGitRepo(tfDir, t)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve test directory: %v", err)
 	}
 
-	return test_structure.CopyTerraformFolderToTemp(t, getRepoRoot, testDirRelPathFromGitRepo), nil
-}
-
-func resolveTfDir(tfDir string, repoRoot string) (string, error) {
-	if !strings.HasPrefix(tfDir, "/") {
-		currentDir, _ := os.Getwd()
-		resolvedPath, err := filepath.Rel(repoRoot, filepath.Join(currentDir, tfDir))
-		if err != nil {
-			return "", fmt.Errorf("failed to get relative path to git repo: %v", err)
-		}
-		return resolvedPath, nil
-	}
-	return strings.TrimPrefix(tfDir, repoRoot), nil
+	return test_structure.CopyTerraformFolderToTemp(t, gitRepoRoot, testDirRelPathFromGitRepo), nil
 }

--- a/pkg/scenario/terraformdir.go
+++ b/pkg/scenario/terraformdir.go
@@ -1,19 +1,17 @@
 package scenario
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/Excoriate/tftest/pkg/validation"
 )
 
+// GetTerraformDir returns the Terraform directory path.
+// It's used to get the Terraform directory path for the scenario.
+// If the scenario is running in parallel, it sets up the Terraform directory for parallelism.
 func GetTerraformDir(t *testing.T, path string, isParallel bool) (string, error) {
-	if err := validation.IsValidTFDir(path); err != nil {
-		return "", fmt.Errorf("invalid terraform directory: %v", err)
-	}
-
-	if err := validation.HasTerraformFiles(path, []string{".tf"}); err != nil {
-		return "", fmt.Errorf("no terraform files found in directory: %v", err)
+	if err := validation.IsValidTFModuleDir(path); err != nil {
+		return "", err
 	}
 
 	if isParallel {

--- a/pkg/tfdir/dirs.go
+++ b/pkg/tfdir/dirs.go
@@ -1,0 +1,44 @@
+package tfdir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/git"
+)
+
+// GetRelativePathFromGitRepo returns the relative path to the git repo root.
+// It is used to get the relative path to the git repo root for the Terraform directory.
+// If the Terraform directory is an absolute path, it returns the relative path to the git repo root.
+// If the Terraform directory is a relative path, it returns the relative path to the git repo root.
+func GetRelativePathFromGitRepo(tfDir string, t *testing.T) (string, string, error) {
+	if tfDir == "" {
+		return "", "", fmt.Errorf("tfDir is required")
+	}
+
+	repoRoot := git.GetRepoRoot(t)
+
+	t.Logf("The git repo root is %s", repoRoot)
+
+	if !filepath.IsAbs(tfDir) {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get current directory: %v", err)
+		}
+		resolvedPath, err := filepath.Rel(repoRoot, filepath.Join(currentDir, tfDir))
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get relative path to git repo: %v", err)
+		}
+
+		return resolvedPath, repoRoot, nil
+	}
+
+	if !strings.HasPrefix(tfDir, repoRoot) {
+		return "", "", fmt.Errorf("the tfdir passed %s does not start with the repo root %s", tfDir, repoRoot)
+	}
+
+	return strings.TrimPrefix(tfDir, repoRoot), repoRoot, nil
+}

--- a/pkg/utils/git.go
+++ b/pkg/utils/git.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// IsAGitRepository checks if the given directory is a git repository.
+func IsAGitRepository(repoRoot string) error {
+	if repoRoot == "" {
+		return fmt.Errorf("directory path cannot be empty")
+	}
+
+	if err := DirExistAndHasContent(repoRoot); err != nil {
+		return err
+	}
+
+	_, err := os.Stat(filepath.Join(repoRoot, ".git"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("directory %s is not a git repository", repoRoot)
+		}
+
+		return fmt.Errorf("unexpected error when checking the directory %s: %v", repoRoot, err)
+	}
+
+	return nil
+}

--- a/pkg/validation/terraform.go
+++ b/pkg/validation/terraform.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Excoriate/tftest/pkg/utils"
 )
 
+// HasTerraformFiles checks if the given directory has Terraform files with the given extensions.
+// If the directory does not have any Terraform files with the given extensions, it returns an error.
 func HasTerraformFiles(path string, extensions []string) error {
 	files, err := filepath.Glob(filepath.Join(path, path, "*"))
 	if err != nil {
@@ -25,6 +27,8 @@ func HasTerraformFiles(path string, extensions []string) error {
 	return nil
 }
 
+// IsValidTFDir checks if the given path is a valid Terraform directory.
+// A valid Terraform directory is a directory that exists and is not empty.
 func IsValidTFDir(path string) error {
 	tfDirInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {
@@ -38,6 +42,8 @@ func IsValidTFDir(path string) error {
 	return nil
 }
 
+// IsValidTFVarFile checks if the given path is a valid Terraform variable file.
+// A valid Terraform variable file is a file with the .tfvars extension that is not empty.
 func IsValidTFVarFile(path string) error {
 	fileInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {
@@ -54,6 +60,21 @@ func IsValidTFVarFile(path string) error {
 
 	if err := utils.FileHasContent(path); err != nil {
 		return fmt.Errorf("the terraform variable file is empty: %s", path)
+	}
+
+	return nil
+}
+
+// IsValidTFModuleDir checks if the given path is a valid Terraform module directory.
+// A valid Terraform module directory is a directory that contains at least one Terraform file with the .tf extension.
+// The path must also be a valid directory.
+func IsValidTFModuleDir(path string) error {
+	if err := IsValidTFDir(path); err != nil {
+		return err
+	}
+
+	if err := HasTerraformFiles(path, []string{".tf"}); err != nil {
+		return err
 	}
 
 	return nil

--- a/test/examples/simple/with_options_test.go
+++ b/test/examples/simple/with_options_test.go
@@ -45,3 +45,11 @@ func TestWithParallelism(t *testing.T) {
 
 	s.Stg.PlanStage(t, s.GetTerraformOptions())
 }
+
+func TestWithRetryOptions(t *testing.T) {
+	workdir := "../../data/tf-random"
+	s, err := scenario.NewWithOptions(t, workdir, scenario.WithRetry(map[string]string{"Error": "Error"}, 5, 3))
+	assert.NoErrorf(t, err, "Failed to create scenario: %s", err)
+
+	s.Stg.PlanStage(t, s.GetTerraformOptions())
+}


### PR DESCRIPTION
Refactor the SetupTerraformDirForParallelism function to use the new tfdir
package for calculating the relative path to the git repo root. This
improves the code readability and maintainability.

feat: Add functions to validate Terraform files and directories

Introduce new functions in the validation package to check if a directory
contains Terraform files with specific extensions and if a directory is a
valid Terraform module directory. These functions enhance the validation
capabilities for Terraform configurations.

feat: Add IsAGitRepository function

Include a new function in the utils package to determine if a directory
is a git repository. This function verifies the presence of a .git
directory within the provided path, enhancing the git repository
detection process.

fix: Update test file for scenario with retry options

Adjust the test file for scenarios with retry options to include the
correct package import for the tfdir package, ensuring the test
functionality remains consistent.