### PR TITLE
feat: add support for JSONPath testcases

### DIFF
--- a/pkg/scenario/stage.go
+++ b/pkg/scenario/stage.go
@@ -45,6 +45,7 @@ type Stage interface {
 	PlanWithResourcesExpectedToBeDeleted(t *testing.T, options *terraform.Options, resources []string)
 	PlanWithResourcesExpectedToBeUpdated(t *testing.T, options *terraform.Options, resources []string)
 	PlanWithSpecificVariableValueToExpect(t *testing.T, options *terraform.Options, variable, value string)
+	PlanAndAssertJSONWithJSONPath(t *testing.T, options *terraform.Options, testCases []JSONPathTestCases)
 }
 
 func (c *StageClient) DestroyStage(t *testing.T, options *terraform.Options) {

--- a/pkg/scenario/stage.go
+++ b/pkg/scenario/stage.go
@@ -215,7 +215,7 @@ func (c *StageClient) PlanAndAssertJSONWithJSONPath(t *testing.T, options *terra
 	}
 }
 
-func applyTestType(t *testing.T, testType TestType, actual interface{}, expected interface{}, additionalMessage string) {
+func applyTestType(t *testing.T, testType TestType, actual, expected interface{}, additionalMessage string) {
 	switch testType {
 	case ShouldContain:
 		msg := fmt.Sprintf("Output did not contains the expected value. Expected: %v, Actual: %v, %s", expected, actual, additionalMessage)

--- a/pkg/scenario/stage.go
+++ b/pkg/scenario/stage.go
@@ -24,10 +24,10 @@ const (
 	ShouldBeEqual
 )
 
-type JsonPathTestCases struct {
+type JSONPathTestCases struct {
 	TestName           string
 	ExpectedValue      interface{}
-	JsonPathToCompare  string
+	JSONPathToCompare  string
 	AllowDifferentType bool
 	TestType           TestType
 }
@@ -185,18 +185,18 @@ func (c *StageClient) PlanWithSpecificVariableValueToExpect(t *testing.T, option
 	compareValues(t, actualValue, expectedValue, variable)
 }
 
-// PlanAndAssertJsonWithJsonPath performs JSON path planning and assertion in Go testing.
+// PlanAndAssertJSONWithJSONPath performs JSON path planning and assertion in Go testing.
 //
 // t *testing.T: Testing object
 // options *terraform.Options: Terraform options
-// testCases []JsonPathTestCases: Array of JSON path test cases
-func (c *StageClient) PlanAndAssertJsonWithJsonPath(t *testing.T, options *terraform.Options, testCases []JsonPathTestCases) {
+// testCases []JSONPathTestCases: Array of JSON path test cases
+func (c *StageClient) PlanAndAssertJSONWithJSONPath(t *testing.T, options *terraform.Options, testCases []JSONPathTestCases) {
 	jsonPlan := terraform.InitAndPlanAndShow(t, options)
 
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
 			var result []interface{}
-			k8s.UnmarshalJSONPath(t, []byte(jsonPlan), testCase.JsonPathToCompare, &result)
+			k8s.UnmarshalJSONPath(t, []byte(jsonPlan), testCase.JSONPathToCompare, &result)
 			assert.NotNil(t, result)
 
 			// if expected is slice then it's ok to compare entire slice
@@ -209,7 +209,7 @@ func (c *StageClient) PlanAndAssertJsonWithJsonPath(t *testing.T, options *terra
 				if !testCase.AllowDifferentType {
 					assert.Equal(t, reflect.TypeOf(testCase.ExpectedValue).Kind(), reflect.TypeOf(v).Kind())
 				}
-				applyTestType(t, testCase.TestType, v, testCase.ExpectedValue, fmt.Sprintf("JSONPATH query: %s", testCase.JsonPathToCompare))
+				applyTestType(t, testCase.TestType, v, testCase.ExpectedValue, fmt.Sprintf("JSONPATH query: %s", testCase.JSONPathToCompare))
 			}
 		})
 	}


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ What changes have you made? (High-level overview)
Implemented support for multiple TestCase analyzing the plan with JsonPath queryes

* 🎉 What does it mean to the user? (In plain English)

User can run some tests with the following model:

```go
//[...]
tc := []scenario.JsonPathTestCases{
		{
			TestName:           "isIRSA",
			JsonPathToCompare:  "{$.planned_values.outputs.is_irsa.value}",
			ExpectedValue:      false,
			TestType:           scenario.ShouldBeEqual,
			AllowDifferentType: false,
		},
		{
			TestName:           "isPodIdentity",
			JsonPathToCompare:  "{$.planned_values.outputs.is_pod_identity.value}",
			ExpectedValue:      true,
			TestType:           scenario.ShouldBeEqual,
			AllowDifferentType: false,
		},
}
s.Stg.PlanAndAssertJsonWithJsonPath(t, s.GetTerraformOptions(), tc)
```
